### PR TITLE
Have the Decoder return salient states

### DIFF
--- a/test/protocol.cpp
+++ b/test/protocol.cpp
@@ -10,6 +10,7 @@
 
 TEST_CASE("Protocol Encode Simple String")
 {
+    INFO("FIXME - make this test assert state transitions");
     const char *mimeType{"application/text"};
 
     const char *message{"I am the very model of a modern major general"};
@@ -18,18 +19,18 @@ TEST_CASE("Protocol Encode Simple String")
 
     // dont forget the null terminatlr
     auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (unsigned char *)message);
-    assert(status == tipsy::ProtocolEncoder::OK);
+    REQUIRE(status == tipsy::ProtocolEncoder::OK);
     for (int i = 0; i < 50; ++i)
     {
         float nf;
         auto st = pe.getNextMessageFloat(nf);
-        std::cout << st << " " << nf;
+        // std::cout << st << " " << nf;
         if (nf <= 10 && nf >= -10)
         {
             unsigned char d[3];
             tipsy::floatToThreeBytes(nf, d);
-            for (int q = 0; q < 3; ++q)
-                std::cout << " " << (int)d[q];
+            /*for (int q = 0; q < 3; ++q)
+                std::cout << " " << (int)d[q]; */
         }
         std::cout << std::endl;
     }
@@ -50,12 +51,28 @@ TEST_CASE("Encode Decode String")
     // dont forget the null terminate
     auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (unsigned char *)message);
     assert(status == tipsy::ProtocolEncoder::OK);
+    bool gotHeader{false}, gotBody{false};
     for (int i = 0; i < 50; ++i)
     {
         float nf;
         auto st = pe.getNextMessageFloat(nf);
         auto rf = pd.readFloat(nf);
+
+        REQUIRE(!pd.isError(rf));
+
+        if (gotBody && gotHeader)
+        {
+            REQUIRE(rf == tipsy::ProtocolDecoder::DORMANT);
+        }
+        if (rf == tipsy::ProtocolDecoder::HEADER_READY)
+        {
+            REQUIRE(std::string(pd.getMimeType()) == std::string(mimeType));
+            gotHeader = true;
+        }
+        if (rf == tipsy::ProtocolDecoder::BODY_READY)
+        {
+            REQUIRE(std::string((const char *)buffer) == std::string(message));
+            gotBody = true;
+        }
     }
-    REQUIRE(std::string(pd.getMimeType()) == std::string(mimeType));
-    REQUIRE(std::string((const char *)buffer) == std::string(message));
 }


### PR DESCRIPTION
The Decoder API now returns states as it parses and the regtest, albeit still too simple, checks them.