### PR TITLE
Union for float type alias plus codec, tweaks, tests

### DIFF
--- a/include/tipsy/binary-to-float.h
+++ b/include/tipsy/binary-to-float.h
@@ -27,26 +27,26 @@ union FloatBytes
     unsigned char bytes[4];
     float f;
 
-    operator float() { return f; }
+    operator float() noexcept { return f; }
 
-    unsigned char first() { return bytes[0]; }
-    unsigned char second() { return bytes[1]; }
-    unsigned char third() { return (bytes[2] & LOW_7_MASK) | (bytes[3] & BIT_8_MASK); }
+    unsigned char first() noexcept { return bytes[0]; }
+    unsigned char second() noexcept { return bytes[1]; }
+    unsigned char third() noexcept { return (bytes[2] & LOW_7_MASK) | (bytes[3] & BIT_8_MASK); }
 
-    FloatBytes(float f)
+    FloatBytes(float f) noexcept
     {
         this->f = f;
     }
 
-    FloatBytes()
+    FloatBytes() noexcept
     {
         bytes[0] = 0;
         bytes[1] = 0;
         bytes[2] = 0;
-        bytes[3] = 0x3f;
+        bytes[3] = EXPONENT_FILL;
     }
 
-    FloatBytes(unsigned char b1, unsigned char b2)
+    FloatBytes(unsigned char b1, unsigned char b2) noexcept
     {
         bytes[0] = b1;
         bytes[1] = b2;
@@ -54,7 +54,7 @@ union FloatBytes
         bytes[3] = EXPONENT_FILL;
     }
 
-    FloatBytes(uint16_t value)
+    FloatBytes(uint16_t value) noexcept
     {
         bytes[0] = value & BYTE_MASK;
         bytes[1] = (value >> 8) & BYTE_MASK;
@@ -62,15 +62,14 @@ union FloatBytes
         bytes[3] = EXPONENT_FILL;
     }
 
-    static bool isRepresentable(uint32_t value)
+    // Not all uint32_t values are representable in this format
+    static bool isRepresentable(uint32_t value) noexcept
     {
         return 0 == (value & (uint32_t)0xFF000000);
     }
 
-    FloatBytes(uint32_t value)
+    FloatBytes(uint32_t value) noexcept
     {
-        // Not all uint32_t values are representable in this format
-        // Should this state raise an exception? 
         assert(isRepresentable(value));
         bytes[0] = value & BYTE_MASK;
         bytes[1] = (value >> 8) & BYTE_MASK;
@@ -79,7 +78,8 @@ union FloatBytes
         bytes[3] = (b3 & BIT_8_MASK) | EXPONENT_FILL;
     }
 
-    FloatBytes(unsigned char b1, unsigned char b2, unsigned char b3) {
+    FloatBytes(unsigned char b1, unsigned char b2, unsigned char b3) noexcept
+    {
         bytes[0] = b1;
         bytes[1] = b2;
         bytes[2] = b3 & LOW_7_MASK;
@@ -87,34 +87,35 @@ union FloatBytes
     }
 };
 
-inline uint16_t uint16_FromFloat(float f)
+inline uint16_t uint16_FromFloat(float f) noexcept
 {
     auto fb = FloatBytes(f);
+    assert(0 == fb.bytes[2]);
     return fb.bytes[0] | (fb.bytes[1] << 8);
 }
 
-inline uint32_t uint32_FromFloat(float f)
+inline uint32_t uint32_FromFloat(float f) noexcept
 {
     auto fb = FloatBytes(f);
     return fb.first() | (fb.second() << 8) | (fb.third() << 16);
 }
 
-inline float threeBytesToFloat(unsigned char b1, unsigned char b2, unsigned char b3)
+inline float threeBytesToFloat(unsigned char b1, unsigned char b2, unsigned char b3) noexcept
 {
     return FloatBytes(b1, b2, b3).f;
 }
 
-inline unsigned char FirstByte(float f)
+inline unsigned char FirstByte(float f) noexcept
 {
     return FloatBytes(f).first();
 }
 
-inline unsigned char SecondByte(float f)
+inline unsigned char SecondByte(float f) noexcept
 {
     return FloatBytes(f).second();
 }
 
-inline unsigned char ThirdByte(float f)
+inline unsigned char ThirdByte(float f) noexcept
 {
     return FloatBytes(f).third();
 }

--- a/include/tipsy/binary-to-float.h
+++ b/include/tipsy/binary-to-float.h
@@ -1,43 +1,123 @@
+#pragma once
+#ifndef TIPSY_ENCODER_BINARY_TO_FLOAT_H
+#define TIPSY_ENCODER_BINARY_TO_FLOAT_H
 /*
  * binary-to-float.h
  *
- * low level encoding to take 3 unsigned chars and project them to a single valid float
- * and vice versa.
+ * Low level encoding to take 3 unsigned chars and project them to a single valid float
+ * and vice versa. The values used are designed for compatability with VCV Rack voltage standards.
  *
  * The encoding we use is as follows:
  *
  * An IEEE float is: lowest 23 bits are fraction, next 8 are exponent, last is sign bit.
  *
  */
-
-#ifndef TIPSY_ENCODER_BINARY_TO_FLOAT_H
-#define TIPSY_ENCODER_BINARY_TO_FLOAT_H
-
 #include <cstdint>
 
 namespace tipsy
 {
-inline float threeBytesToFloat(const unsigned char *const d)
+
+constexpr const unsigned char BYTE_MASK = 0xff;
+constexpr const unsigned char LOW_7_MASK = 0x7f;
+constexpr const unsigned char BIT_8_MASK = 0x80;
+constexpr const unsigned char EXPONENT_FILL = 0x3f;
+
+union FloatBytes
 {
-    unsigned char enc[4];
-    enc[0] = d[0];
-    enc[1] = d[1];
-    enc[2] = d[2] & 127;
-    enc[3] = (d[2] & 128) | 63;
+    unsigned char bytes[4];
+    float f;
 
-    float res = *((float *)&(enc[0]));
+    operator float() { return f; }
 
-    return res;
+    unsigned char first() { return bytes[0]; }
+    unsigned char second() { return bytes[1]; }
+    unsigned char third() { return (bytes[2] & LOW_7_MASK) | (bytes[3] & BIT_8_MASK); }
+
+    FloatBytes(float f)
+    {
+        this->f = f;
+    }
+
+    FloatBytes()
+    {
+        bytes[0] = 0;
+        bytes[1] = 0;
+        bytes[2] = 0;
+        bytes[3] = 0x3f;
+    }
+
+    FloatBytes(unsigned char b1, unsigned char b2)
+    {
+        bytes[0] = b1;
+        bytes[1] = b2;
+        bytes[2] = 0;
+        bytes[3] = EXPONENT_FILL;
+    }
+
+    FloatBytes(uint16_t value)
+    {
+        bytes[0] = value & BYTE_MASK;
+        bytes[1] = (value >> 8) & BYTE_MASK;
+        bytes[2] = 0;
+        bytes[3] = EXPONENT_FILL;
+    }
+
+    static bool isRepresentable(uint32_t value)
+    {
+        return 0 == (value & (uint32_t)0xFF000000);
+    }
+
+    FloatBytes(uint32_t value)
+    {
+        // Not all uint32_t values are representable in this format
+        // Should this state raise an exception? 
+        assert(isRepresentable(value));
+        bytes[0] = value & BYTE_MASK;
+        bytes[1] = (value >> 8) & BYTE_MASK;
+        unsigned char b3 = (value >> 16) & BYTE_MASK;
+        bytes[2] = b3 & LOW_7_MASK;
+        bytes[3] = (b3 & BIT_8_MASK) | EXPONENT_FILL;
+    }
+
+    FloatBytes(unsigned char b1, unsigned char b2, unsigned char b3) {
+        bytes[0] = b1;
+        bytes[1] = b2;
+        bytes[2] = b3 & LOW_7_MASK;
+        bytes[3] = (b3 & BIT_8_MASK) | EXPONENT_FILL;
+    }
+};
+
+inline uint16_t uint16_FromFloat(float f)
+{
+    auto fb = FloatBytes(f);
+    return fb.bytes[0] | (fb.bytes[1] << 8);
 }
 
-inline void floatToThreeBytes(float f, unsigned char *const d)
+inline uint32_t uint32_FromFloat(float f)
 {
-    auto *y = (unsigned char *)&f;
-
-    d[0] = y[0];
-    d[1] = y[1];
-    d[2] = (y[2] & 127) | (y[3] & 128);
+    auto fb = FloatBytes(f);
+    return fb.first() | (fb.second() << 8) | (fb.third() << 16);
 }
-} // namespace tipsy
 
+inline float threeBytesToFloat(unsigned char b1, unsigned char b2, unsigned char b3)
+{
+    return FloatBytes(b1, b2, b3).f;
+}
+
+inline unsigned char FirstByte(float f)
+{
+    return FloatBytes(f).first();
+}
+
+inline unsigned char SecondByte(float f)
+{
+    return FloatBytes(f).second();
+}
+
+inline unsigned char ThirdByte(float f)
+{
+    return FloatBytes(f).third();
+}
+
+}
 #endif // TIPSY_ENCODER_BINARY_TO_FLOAT_H

--- a/include/tipsy/protocol.h
+++ b/include/tipsy/protocol.h
@@ -1,17 +1,18 @@
+#pragma once
+#ifndef TIPSY_ENCODER_PROTOCOL_H
+#define TIPSY_ENCODER_PROTOCOL_H
 /*
  * Given an encoder for raw binary, we need a communications protocol. This sort of
  * lays one out with a stateful encoder and decoder object.
  *
- * We have to take great care to have these be audio thread safe, so allocation and copies
+ * We have to take great care to have these be audio thread safe, so heap heap allocation and copies
  * are things we try hard not to do. Please carefully read the comments on functions to make
  * sure you get the ownership correct.
  */
 
-#ifndef TIPSY_ENCODER_PROTOCOL_H
-#define TIPSY_ENCODER_PROTOCOL_H
-
 #include <cstdint>
 #include <cstring>
+#include "tipsy.h"
 
 #if __cplusplus >= 201703L
 #define TIPSY_NODISCARD [[nodiscard]]
@@ -30,50 +31,70 @@ static constexpr float kSizeSentinel{13.f};
 static constexpr float kMimeTypeSentinel{14.f};
 static constexpr float kBodySentinel{15.f};
 static constexpr float kEndMessageSentinel{16.f};
+
 static constexpr uint16_t kVersion{0x01};
-static constexpr size_t kMaxMimeTypeSize{1024};
+
+// limits
+static constexpr size_t kMaxMimeTypeSize{256};
+static constexpr size_t kMaxMessageLength{1 << 23};
 
 struct ProtocolEncoder
 {
-    enum EncoderResult : uint16_t
+    enum class EncoderResult : uint16_t
     {
         DORMANT = 1,
         ENCODING_MESSAGE,
         MESSAGE_COMPLETE,
         MESSAGE_TERMINATED,
-
         MESSAGE_INITIATED,
 
-        ERROR_UNKNOWN = 1 << 7,
+        ERROR_UNKNOWN = 0x100,
         ERROR_NO_MESSAGE_ACTIVE,
         ERROR_MESSAGE_TOO_LARGE,
         ERROR_MIME_TYPE_TOO_LARGE,
-        ERROR_MESSAGE_ALREADY_ACTIVE
+        ERROR_MESSAGE_ALREADY_ACTIVE,
+        ERROR_MISSING_MIME_TYPE,
+        ERROR_MISSING_DATA,
     };
 
     bool isError(EncoderResult r)
     {
-        if (((uint16_t)r) & ((uint16_t)ERROR_UNKNOWN))
-            return true;
-        return false;
+        return r >= EncoderResult::ERROR_UNKNOWN;
     }
 
     TIPSY_NODISCARD
     EncoderResult initiateMessage(const char *inMimeType, uint32_t inDataBytes,
                                   const unsigned char *const inData)
     {
-        if (inDataBytes > 1 << 23)
+        if (inDataBytes > kMaxMessageLength)
         {
-            return ERROR_MESSAGE_TOO_LARGE;
+            return EncoderResult::ERROR_MESSAGE_TOO_LARGE;
+        }
+        if ((inDataBytes > 0) && (nullptr == inData))
+        {
+            return EncoderResult::ERROR_MISSING_DATA;
+        }
+        if (nullptr == inMimeType)
+        if (inDataBytes > kMaxMessageLength)
+        {
+            return EncoderResult::ERROR_MESSAGE_TOO_LARGE;
+        }
+        if ((inDataBytes > 0) && (nullptr == inData))
+        {
+            return EncoderResult::ERROR_MISSING_DATA;
+        }
+        if (nullptr == inMimeType)
+        {
+            return EncoderResult::ERROR_MISSING_MIME_TYPE;
         }
         auto ms = strlen(inMimeType) + 1;
         if (ms > kMaxMimeTypeSize)
         {
-            return ERROR_MIME_TYPE_TOO_LARGE;
+            return EncoderResult::ERROR_MIME_TYPE_TOO_LARGE;
         }
         if (!isDormant())
         {
-            return ERROR_MESSAGE_ALREADY_ACTIVE;
+            return EncoderResult::ERROR_MESSAGE_ALREADY_ACTIVE;
         }
 
         mimeType = inMimeType;
@@ -81,9 +102,9 @@ struct ProtocolEncoder
         data = inData;
         dataBytes = inDataBytes;
 
-        setState(START_MESSAGE);
+        setState(EncoderState::START_MESSAGE);
 
-        return MESSAGE_INITIATED;
+        return EncoderResult::MESSAGE_INITIATED;
     }
 
     TIPSY_NODISCARD
@@ -91,22 +112,25 @@ struct ProtocolEncoder
     {
         switch (encoderState)
         {
-        case NO_MESSAGE:
+        case EncoderState::NO_MESSAGE:
             f = 0;
-            return DORMANT;
+            return EncoderResult::DORMANT;
+            return EncoderResult::DORMANT;
             break;
-        case START_MESSAGE:
+        case EncoderState::START_MESSAGE:
         {
             f = kMessageBeginSentinel;
             pos++;
             if (pos == 3)
             {
-                setState(HEADER_VERSION);
+                setState(EncoderState::HEADER_VERSION);
+                setState(EncoderState::HEADER_VERSION);
             }
-            return ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
             break;
         }
-        case HEADER_VERSION:
+        case EncoderState::HEADER_VERSION:
         {
             if (pos == 0)
             {
@@ -115,17 +139,13 @@ struct ProtocolEncoder
             }
             else
             {
-                unsigned char d[3];
-                d[0] = kVersion & 255;
-                d[1] = (kVersion >> 8) & 255;
-                d[2] = 0;
-                f = threeBytesToFloat(d);
-                setState(HEADER_SIZE);
+                f = FloatBytes(kVersion);
+                setState(EncoderState::HEADER_SIZE);
             }
-            return ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
         }
         break;
-        case HEADER_SIZE:
+        case EncoderState::HEADER_SIZE:
         {
             if (pos == 0)
             {
@@ -134,18 +154,13 @@ struct ProtocolEncoder
             }
             else
             {
-                unsigned char d[3];
-                d[0] = dataBytes & 255;
-                d[1] = (dataBytes >> 8) & 255;
-                d[2] = (dataBytes >> 16) & 255;
-
-                f = threeBytesToFloat(d);
-                setState(HEADER_MIMETYPE);
+                f = FloatBytes(dataBytes);
+                setState(EncoderState::HEADER_MIMETYPE);
             }
-            return ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
         }
         break;
-        case HEADER_MIMETYPE:
+        case EncoderState::HEADER_MIMETYPE:
         {
             if (pos == 0)
             {
@@ -154,13 +169,7 @@ struct ProtocolEncoder
             }
             else if (pos == 1)
             {
-                auto sl = mimeTypeSize;
-                unsigned char d[3];
-                d[0] = sl & 255;
-                d[1] = (sl >> 8) & 255;
-                d[2] = (sl >> 16) & 255;
-
-                f = threeBytesToFloat(d);
+                f = FloatBytes(mimeTypeSize);
                 pos++;
             }
             else
@@ -168,31 +177,31 @@ struct ProtocolEncoder
                 auto dp = pos - 2;
                 if (dp < mimeTypeSize - 3)
                 {
-                    f = threeBytesToFloat((unsigned char *)(mimeType + dp));
+                    auto mt = (unsigned char *)(mimeType + dp);
+                    f = FloatBytes(mt[0], mt[1], mt[2]);
 
                     pos += 3;
                     if (pos - 1 == mimeTypeSize)
                     {
-                        setState(BODY);
+                        setState(EncoderState::BODY);
                     }
                 }
                 else
                 {
                     char d[3]{0, 0, 0};
                     int i{0};
-                    for (; dp < mimeTypeSize; ++dp)
+                    for (; dp < mimeTypeSize; ++dp, ++i, ++i)
                     {
                         d[i] = mimeType[dp];
-                        i++;
                     }
-                    f = threeBytesToFloat((unsigned char *)d);
-                    setState(BODY);
+                    f = FloatBytes(d[0], d[1], d[2]);
+                    setState(EncoderState::BODY);
                 }
             }
-            return ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
         }
         break;
-        case BODY:
+        case EncoderState::BODY:
         {
             if (pos == 0)
             {
@@ -201,68 +210,67 @@ struct ProtocolEncoder
             }
             else if (pos - 1 == dataBytes)
             {
-                setState(END_MESSAGE);
+                setState(EncoderState::END_MESSAGE);
             }
             else if (pos - 1 < dataBytes - 3)
             {
-                f = threeBytesToFloat((unsigned char *)(data + pos - 1));
-
+                auto d = data + pos - 1;
+                f = FloatBytes(d[0], d[1], d[2]);
                 pos += 3;
                 if (pos - 1 == dataBytes)
                 {
-                    setState(END_MESSAGE);
+                    setState(EncoderState::END_MESSAGE);
                 }
             }
             else
             {
-                auto dp = pos - 1;
-                char d[3]{0, 0, 0};
+                unsigned char d[3]{0, 0, 0};
                 int i{0};
-                for (; dp < dataBytes; ++dp)
+                for (unsigned int dpos = pos - 1; dpos < dataBytes; ++dpos, ++i)
                 {
-                    d[i] = data[dp];
-                    i++;
+                    d[i] = data[dpos];
                 }
-                f = threeBytesToFloat((unsigned char *)d);
-                setState(END_MESSAGE);
+                f = FloatBytes(d[0], d[1], d[2]);
+                setState(EncoderState::END_MESSAGE);
             }
-            return ENCODING_MESSAGE;
+            return EncoderResult::ENCODING_MESSAGE;
         }
         break;
-        case END_MESSAGE:
+        case EncoderState::END_MESSAGE:
         {
             f = kEndMessageSentinel;
-            setState(NO_MESSAGE);
-            return MESSAGE_COMPLETE;
+            setState(EncoderState::NO_MESSAGE);
+            return EncoderResult::MESSAGE_COMPLETE;
         }
         break;
         }
 
-        return ERROR_UNKNOWN;
+        return EncoderResult::ERROR_UNKNOWN;
     }
 
     TIPSY_NODISCARD
     EncoderResult terminateCurrentMessage()
     {
-        if (encoderState == NO_MESSAGE)
+        if (encoderState == EncoderState::NO_MESSAGE)
         {
-            return ERROR_NO_MESSAGE_ACTIVE;
+            return EncoderResult::ERROR_NO_MESSAGE_ACTIVE;
         }
-        setState(NO_MESSAGE);
-        return MESSAGE_TERMINATED;
+        setState(EncoderState::NO_MESSAGE);
+        return EncoderResult::MESSAGE_TERMINATED;
     }
 
     bool isDormant()
     {
-        return encoderState == NO_MESSAGE;
+        return encoderState == EncoderState::NO_MESSAGE;
     }
 
   private:
-    const char *mimeType{nullptr};
-    uint32_t dataBytes{0}, mimeTypeSize{0};
-    const unsigned char *data;
+    const char * mimeType{nullptr};
+    uint32_t dataBytes{0};
+    uint16_t mimeTypeSize{0};
+    const unsigned char *data{nullptr};
 
-    enum EncoderStates
+    enum class EncoderState: uint16_t
     {
         NO_MESSAGE,
         START_MESSAGE,
@@ -271,11 +279,11 @@ struct ProtocolEncoder
         HEADER_MIMETYPE,
         BODY,
         END_MESSAGE
-    } encoderState{NO_MESSAGE};
+    } encoderState{EncoderState::NO_MESSAGE};
 
-    int pos{0};
+    unsigned int pos{0};
 
-    void setState(EncoderStates s)
+    void setState(EncoderState s)
     {
         encoderState = s;
         pos = 0;
@@ -284,7 +292,7 @@ struct ProtocolEncoder
 
 struct ProtocolDecoder
 {
-    enum DecoderResult : uint16_t
+    enum class DecoderResult : uint16_t
     {
         DORMANT = 1,
         PARSING_HEADER,
@@ -292,30 +300,24 @@ struct ProtocolDecoder
         PARSING_BODY,
         BODY_READY,
 
-        ERROR_UNKNOWN = 1 << 8, // set this bit for all the errors
+        ERROR_UNKNOWN = 0x100,
         ERROR_INCOMPATIBLE_VERSION,
         ERROR_MALFORMED_HEADER,
-        ERROR_DATA_TOO_LARGE,
-
-        // OK,
-        // NOT_OK
+        ERROR_DATA_TOO_LARGE
     };
 
-    bool isError(DecoderResult r)
+    static bool isError(DecoderResult r)
     {
-        if (((uint16_t)r) & ((uint16_t)ERROR_UNKNOWN))
-            return true;
-        return false;
+        return r >= DecoderResult::ERROR_UNKNOWN;
     }
 
-    bool provideDataBuffer(unsigned char *pdat, size_t psize)
+    bool provideDataBuffer(unsigned char * data, int size)
     {
-        if (decoderState == START_BODY)
+        if (decoderState == DecoderState::START_BODY)
             return false;
 
-        dataStore = pdat;
-        dataStoreSize = psize;
-
+        dataStore = data;
+        dataStoreSize = size;
         return true;
     }
 
@@ -326,140 +328,129 @@ struct ProtocolDecoder
     {
         if (f == kMessageBeginSentinel)
         {
-            setState(START_HEADER);
+            setState(DecoderState::START_HEADER);
             dataSize = 0;
             memset(mimetype, 0, sizeof(mimetype));
             version = -1;
-            return PARSING_HEADER;
+            return DecoderResult::PARSING_HEADER;
         }
 
         // Use sentinels to force state for next read
         if (f == kVersionSentinel)
         {
-            setState(START_VERSION);
-            return PARSING_HEADER;
+            setState(DecoderState::START_VERSION);
+            return DecoderResult::PARSING_HEADER;
         }
         if (f == kSizeSentinel)
         {
-            setState(START_SIZE);
-            return PARSING_HEADER;
+            setState(DecoderState::START_SIZE);
+            return DecoderResult::PARSING_HEADER;
         }
         if (f == kMimeTypeSentinel)
         {
-            setState(START_MIMETYPE);
-            return PARSING_HEADER;
+            setState(DecoderState::START_MIMETYPE);
+            return DecoderResult::PARSING_HEADER;
         }
         if (f == kBodySentinel)
         {
-            setState(START_BODY);
-            return HEADER_READY;
+            setState(DecoderState::START_BODY);
+            return DecoderResult::HEADER_READY;
         }
         if (f == kEndMessageSentinel)
         {
-            setState(DOING_NOTHING);
-            return BODY_READY;
+            setState(DecoderState::DOING_NOTHING);
+            return DecoderResult::BODY_READY;
         }
 
         switch (decoderState)
         {
-        case DOING_NOTHING:
-            return DORMANT;
-        case START_HEADER:
-            return PARSING_HEADER;
-        case START_VERSION:
+        case DecoderState::DOING_NOTHING:
+            return DecoderResult::DORMANT;
+        case DecoderState::START_HEADER:
+            return DecoderResult::PARSING_HEADER;
+        case DecoderState::START_VERSION:
             if (pos == 0)
             {
-                unsigned char d[3];
-                floatToThreeBytes(f, d);
-                version = d[0] + (d[1] << 8);
+                version = uint16_FromFloat(f);
                 pos++;
                 if (version > 0 && version <= kVersion)
                 {
-                    return PARSING_HEADER;
+                    return DecoderResult::PARSING_HEADER;
                 }
                 else
                 {
-                    return ERROR_INCOMPATIBLE_VERSION;
+                    return DecoderResult::ERROR_INCOMPATIBLE_VERSION;
                 }
             }
             else
             {
-                return ERROR_MALFORMED_HEADER;
+                return DecoderResult::ERROR_MALFORMED_HEADER;
             }
             break;
 
-        case START_SIZE:
+        case DecoderState::START_SIZE:
             if (pos == 0)
             {
-                unsigned char d[3];
-                floatToThreeBytes(f, d);
-                dataSize = d[0] + (d[1] << 8) + (d[2] << 16);
+                dataSize = uint32_FromFloat(f);
                 pos++;
-                return PARSING_HEADER;
+                return DecoderResult::PARSING_HEADER;
             }
             else
             {
-                return ERROR_MALFORMED_HEADER;
+                return DecoderResult::ERROR_MALFORMED_HEADER;
             }
             break;
 
-        case START_MIMETYPE:
+        case DecoderState::START_MIMETYPE:
         {
             if (pos == 0)
             {
-                unsigned char d[3];
-                floatToThreeBytes(f, d);
-                mimetypeSize = d[0] + (d[1] << 8);
-
+                mimetypeSize = uint16_FromFloat(f);
                 pos++;
-                return PARSING_HEADER;
+                return DecoderResult::PARSING_HEADER;
             }
             else
             {
                 if (pos > mimetypeSize)
                 {
-                    return ERROR_MALFORMED_HEADER;
+                    return DecoderResult::ERROR_MALFORMED_HEADER;
                 }
-                unsigned char d[3];
-                floatToThreeBytes(f, d);
-
-                if (pos >= kMaxMimeTypeSize - 4)
-                    return ERROR_DATA_TOO_LARGE;
+                if (pos >= kMaxMimeTypeSize - 4) {
+                    return DecoderResult::ERROR_DATA_TOO_LARGE;
+                }
 
                 auto wp = pos - 1;
-                mimetype[wp] = d[0];
-                mimetype[wp + 1] = d[1];
-                mimetype[wp + 2] = d[2];
+                auto float_bytes = FloatBytes(f);
+                mimetype[wp] = float_bytes.first();
+                mimetype[wp + 1] = float_bytes.second();
+                mimetype[wp + 2] = float_bytes.third();
 
                 pos += 3;
-                return PARSING_HEADER;
+                return DecoderResult::PARSING_HEADER;
             }
             break;
         }
-        case START_BODY:
-            unsigned char d[3];
-            floatToThreeBytes(f, d);
-
-            if (pos < dataStoreSize + 3)
+        case DecoderState::START_BODY:
+            if (pos < dataStoreSize - 3)
             {
-                dataStore[pos] = d[0];
-                dataStore[pos + 1] = d[1];
-                dataStore[pos + 2] = d[2];
-                pos += 3;
-                return PARSING_BODY;
+                auto float_bytes = FloatBytes(f);
+                dataStore[pos++] = float_bytes.first();
+                dataStore[pos++] = float_bytes.second();
+                dataStore[pos++] = float_bytes.third();
+                return DecoderResult::PARSING_BODY;
             }
             else
             {
-                return ERROR_DATA_TOO_LARGE;
+                return DecoderResult::ERROR_DATA_TOO_LARGE;
             }
             break;
         }
 
-        return ERROR_UNKNOWN;
+        return DecoderResult::ERROR_UNKNOWN;
     }
 
   private:
-    enum DecoderState
+    enum class DecoderState : uint8_t
     {
         DOING_NOTHING,
         START_VERSION,
@@ -467,9 +458,10 @@ struct ProtocolDecoder
         START_SIZE,
         START_MIMETYPE,
         START_BODY
-    } decoderState{DOING_NOTHING};
-    int pos{0};
-    int16_t version;
+    } decoderState{DecoderState::DOING_NOTHING};
+
+    uint32_t pos{0};
+    uint16_t version;
     uint32_t dataSize;
     char mimetype[kMaxMimeTypeSize];
     uint16_t mimetypeSize;
@@ -483,6 +475,10 @@ struct ProtocolDecoder
         pos = 0;
     }
 };
-} // namespace tipsy
 
+// convenience shorthands for client code
+using EncoderResult = ProtocolEncoder::EncoderResult;
+using DecoderResult = ProtocolDecoder::DecoderResult;
+
+} // namespace tipsy
 #endif // TIPSY_ENCODER_PROTOCOL_H

--- a/include/tipsy/protocol.h
+++ b/include/tipsy/protocol.h
@@ -5,9 +5,9 @@
  * Given an encoder for raw binary, we need a communications protocol. This sort of
  * lays one out with a stateful encoder and decoder object.
  *
- * We have to take great care to have these be audio thread safe, so heap heap allocation and copies
- * are things we try hard not to do. Please carefully read the comments on functions to make
- * sure you get the ownership correct.
+ * We have to take great care to have these be audio thread safe, so heap allocation
+ * and copies are things we try hard not to do. Please carefully read the comments on
+ * functions to make sure you get the ownership correct.
  */
 
 #include <cstdint>

--- a/include/tipsy/tipsy.h
+++ b/include/tipsy/tipsy.h
@@ -1,12 +1,12 @@
+#pragma once
+#ifndef TIPSY_ENCODER_TIPSY_H
+#define TIPSY_ENCODER_TIPSY_H
 /*
  * tipsy - an encoder for floats to binaries for virtual modular
  *
  * This file just includes the sub-files if you want to have the entire
  * function set available
  */
-
-#ifndef TIPSY_ENCODER_TIPSY_H
-#define TIPSY_ENCODER_TIPSY_H
 
 #include "version.h"
 #include "binary-to-float.h"

--- a/include/tipsy/version.h
+++ b/include/tipsy/version.h
@@ -1,9 +1,9 @@
-/*
- * Information on version
- */
-
+#pragma once
 #ifndef TIPSY_ENCODER_VERSION_H
 #define TIPSY_ENCODER_VERSION_H
+/*
+ * Tipsy library version
+ */
 
 namespace tipsy
 {

--- a/test/binary.cpp
+++ b/test/binary.cpp
@@ -9,40 +9,36 @@
 TEST_CASE("Binary to Float in range across all binaries")
 {
     // This test can be a touch slow but works fine
-    unsigned char d[3];
     float f;
 
     for (int i = 0; i < 256; i++)
         for (int j = 0; j < 256; j++)
             for (int k = 0; k < 256; k++)
             {
-                d[0] = i;
-                d[1] = j;
-                d[2] = k;
-                f = tipsy::threeBytesToFloat(d);
-                REQUIRE(f > -10);
-                REQUIRE(f < 10);
+                f = tipsy::FloatBytes(i, j, k);
+                REQUIRE(f > -10.f);
+                REQUIRE(f < 10.f);
                 REQUIRE(std::isfinite(f));
+                REQUIRE(!std::isnan(f));
             }
 }
 
 TEST_CASE("Binary to Float Decodable with Fidelity")
 {
     // This test can be a touch slow but works fine
-    unsigned char d[3], e[3];
     float f;
 
     for (int i = 0; i < 256; i++)
         for (int j = 0; j < 256; j++)
             for (int k = 0; k < 256; k++)
             {
-                d[0] = i;
-                d[1] = j;
-                d[2] = k;
-                f = tipsy::threeBytesToFloat(d);
-                tipsy::floatToThreeBytes(f, e);
-                REQUIRE(e[0] == d[0]);
-                REQUIRE(e[1] == d[1]);
-                REQUIRE(e[2] == d[2]);
+                auto fb = tipsy::FloatBytes(i,j,k);
+                REQUIRE(fb.first() == i);
+                REQUIRE(fb.second() == j);
+                REQUIRE(fb.third() == k);
+                f = fb.f;
+                REQUIRE(tipsy::FirstByte(f) == i);
+                REQUIRE(tipsy::SecondByte(f) == j);
+                REQUIRE(tipsy::ThirdByte(f) == k);
             }
 }

--- a/test/protocol.cpp
+++ b/test/protocol.cpp
@@ -11,15 +11,14 @@
 TEST_CASE("Protocol Encode Simple String")
 {
     INFO("FIXME - make this test assert state transitions");
-    const char *mimeType{"application/text"};
-
-    const char *message{"I am the very model of a modern major general"};
+    const char * mimeType{"application/text"};
+    const char * message{"I am the very model of a modern major general"};
 
     tipsy::ProtocolEncoder pe;
 
-    // dont forget the null termination
+    // don't forget null termination
     auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (unsigned char *)message);
-    REQUIRE(status == tipsy::ProtocolEncoder::MESSAGE_INITIATED);
+    REQUIRE(status == tipsy::EncoderResult::MESSAGE_INITIATED);
     bool done{false};
     for (int i = 0; i < 50; ++i)
     {
@@ -28,14 +27,14 @@ TEST_CASE("Protocol Encode Simple String")
 
         if (done)
         {
-            REQUIRE(st == tipsy::ProtocolEncoder::DORMANT);
+            REQUIRE(st == tipsy::EncoderResult::DORMANT);
         }
         else
         {
-            REQUIRE(((st == tipsy::ProtocolEncoder::ENCODING_MESSAGE) ||
-                     (st == tipsy::ProtocolEncoder::MESSAGE_COMPLETE)));
+            REQUIRE(((st == tipsy::EncoderResult::ENCODING_MESSAGE) ||
+                     (st == tipsy::EncoderResult::MESSAGE_COMPLETE)));
         }
-        if (st == tipsy::ProtocolEncoder::MESSAGE_COMPLETE)
+        if (st == tipsy::EncoderResult::MESSAGE_COMPLETE)
         {
             done = true;
         }
@@ -45,7 +44,6 @@ TEST_CASE("Protocol Encode Simple String")
 TEST_CASE("Encode Decode String")
 {
     const char *mimeType{"application/text"};
-
     const char *message{"I am the very model of a modern major general"};
 
     unsigned char buffer[2048];
@@ -54,9 +52,9 @@ TEST_CASE("Encode Decode String")
     tipsy::ProtocolDecoder pd;
     pd.provideDataBuffer(buffer, 2048);
 
-    // dont forget the null terminate
-    auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (unsigned char *)message);
-    REQUIRE(status == tipsy::ProtocolEncoder::MESSAGE_INITIATED);
+    // don't forget null termination
+    auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (const unsigned char *)message);
+    REQUIRE(status == tipsy::EncoderResult::MESSAGE_INITIATED);
     bool gotHeader{false}, gotBody{false};
     for (int i = 0; i < 50; ++i)
     {
@@ -64,20 +62,113 @@ TEST_CASE("Encode Decode String")
         auto st = pe.getNextMessageFloat(nf);
         auto rf = pd.readFloat(nf);
 
-        REQUIRE(!pd.isError(rf));
+        REQUIRE(!tipsy::ProtocolDecoder::isError(rf));
 
         if (gotBody && gotHeader)
         {
-            REQUIRE(rf == tipsy::ProtocolDecoder::DORMANT);
+            REQUIRE(rf == tipsy::DecoderResult::DORMANT);
         }
-        if (rf == tipsy::ProtocolDecoder::HEADER_READY)
+        if (rf == tipsy::DecoderResult::HEADER_READY)
         {
             REQUIRE(std::string(pd.getMimeType()) == std::string(mimeType));
             gotHeader = true;
         }
-        if (rf == tipsy::ProtocolDecoder::BODY_READY)
+        if (rf == tipsy::DecoderResult::BODY_READY)
         {
             REQUIRE(std::string((const char *)buffer) == std::string(message));
+            gotBody = true;
+        }
+    }
+}
+
+TEST_CASE("Require a MIME type")
+{
+    tipsy::ProtocolEncoder pe;
+    auto status = pe.initiateMessage(nullptr, 0, (const unsigned char *)"");
+    REQUIRE(status == tipsy::EncoderResult::ERROR_MISSING_MIME_TYPE);
+}
+
+TEST_CASE("Buffer too small")
+{
+    const char *mimeType{"application/text"};
+    const char *message{"I am the very model of a modern major general"};
+
+    unsigned char buffer[20];
+
+    tipsy::ProtocolEncoder pe;
+    tipsy::ProtocolDecoder pd;
+    pd.provideDataBuffer(buffer, 20);
+
+    // don't forget the terminating null
+    auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (const unsigned char *)message);
+    REQUIRE(status == tipsy::EncoderResult::MESSAGE_INITIATED);
+    bool gotHeader{false}, gotBody{false};
+    for (int i = 0; i < 50; ++i)
+    {
+        float nf;
+        auto st = pe.getNextMessageFloat(nf);
+        auto rf = pd.readFloat(nf);
+
+        //  we expect this error when the message exceeds the buffer
+        if (rf == tipsy::DecoderResult::ERROR_DATA_TOO_LARGE)
+        {
+            return;
+        }
+        REQUIRE(!tipsy::ProtocolDecoder::isError(rf));
+
+        if (gotBody && gotHeader)
+        {
+            REQUIRE(rf == tipsy::DecoderResult::DORMANT);
+        }
+        if (rf == tipsy::DecoderResult::HEADER_READY)
+        {
+            REQUIRE(std::string(pd.getMimeType()) == std::string(mimeType));
+            gotHeader = true;
+        }
+        if (rf == tipsy::DecoderResult::BODY_READY)
+        {
+            REQUIRE(std::string((const char *)buffer) == std::string(message));
+            gotBody = true;
+        }
+    }
+}
+
+
+TEST_CASE("Encode Decode Empty Message")
+{
+    const char * mimeType{"application/text"};
+    const char * message{""};
+
+    unsigned char buffer[2048];
+
+    tipsy::ProtocolEncoder pe;
+    tipsy::ProtocolDecoder pd;
+    pd.provideDataBuffer(buffer, 2048);
+
+    // don't forget the terminating null
+    auto status = pe.initiateMessage(mimeType, strlen(message) + 1, (const unsigned char *)message);
+    REQUIRE(status == tipsy::EncoderResult::MESSAGE_INITIATED);
+    bool gotHeader{false}, gotBody{false};
+    for (int i = 0; i < 50; ++i)
+    {
+        float nf;
+        auto st = pe.getNextMessageFloat(nf);
+        auto rf = pd.readFloat(nf);
+
+        REQUIRE(!tipsy::ProtocolDecoder::isError(rf));
+
+        if (gotBody && gotHeader)
+        {
+            REQUIRE(rf == tipsy::DecoderResult::DORMANT);
+        }
+        if (rf == tipsy::DecoderResult::HEADER_READY)
+        {
+            REQUIRE(std::string(pd.getMimeType()) == std::string(mimeType));
+            gotHeader = true;
+        }
+        if (rf == tipsy::DecoderResult::BODY_READY)
+        {
+            REQUIRE(0 == buffer[0]);
             gotBody = true;
         }
     }


### PR DESCRIPTION
- All tests pass locally (including new ones)

The fundamental change here is in `binary-to-float`. I didn't like the use of unchecked pointers (primitive byte arrays), so implemented a design modelled after a common type-aliasing pattern using a union, adding the special encoding for the 3rd byte, and a number of handy type conversions for better ergonomics. This completed eliminated some of the stack-based buffers, and transformed others to keeping a temp instance of FloatBytes, which is identical in size to the byte buffers. This also simplified and reduced the amount of code needed in protocol.h to implement the encoding and decoding. I seriously doubt there is any loss of efficiency.

Error codes:
- Removed the strange (to me) error bit, and simply segregated errors and result codes into ranges.
- Changed states and result codes to using `enum class`, which prevents both users and library devs from using the wrong entity  because in C/C++ enums just turn into ints and can be freely confused with no compile-time checks to tell you that you got confused. `enum class` adds type checking to the usage, prevent a class of errors that can be made.

Tweaks:
- use `#pragma once` in addition to include guards. For some compilers this performs better than include guards. Using both is a basic portability pattern.
- having guards at the top means compilers don't need to parse comments to skip a header. Sure, it's a super micro-optimization, but in large projects it adds up to a (small) measurable impact on build time (at least, it did in the 90's :-). It's a habit I picked up from when I was a dev on the Visual Studio IDE team.

Tests Added:
- "Require a MIME type"
- "Buffer too small"
- "Encode Decode Empty Message"