### PR TITLE
Fix mimetype encoding

### DIFF
--- a/include/tipsy/protocol.h
+++ b/include/tipsy/protocol.h
@@ -15,7 +15,6 @@
 #include "binary-to-float.h"
 #include "version.h"
 
-
 #if __cplusplus >= 201703L
 #define TIPSY_NODISCARD [[nodiscard]]
 #else

--- a/include/tipsy/protocol.h
+++ b/include/tipsy/protocol.h
@@ -15,6 +15,7 @@
 #include "binary-to-float.h"
 #include "version.h"
 
+
 #if __cplusplus >= 201703L
 #define TIPSY_NODISCARD [[nodiscard]]
 #else
@@ -201,8 +202,8 @@ struct ProtocolEncoder
             }
             else
             {
-                auto dp = pos - 2;
-                if (dp < mimeTypeSize - 3)
+                auto dp = (uint32_t)(pos - 2);
+                if (dp + 3 < mimeTypeSize)
                 {
                     auto mt = (unsigned char *)(mimeType + dp);
                     f = FloatBytes(mt[0], mt[1], mt[2]);
@@ -217,10 +218,11 @@ struct ProtocolEncoder
                 {
                     char d[3]{0, 0, 0};
                     int i{0};
-                    for (; dp < mimeTypeSize; ++dp, ++i, ++i)
+                    for (; dp < mimeTypeSize; ++dp, ++i)
                     {
                         d[i] = mimeType[dp];
                     }
+
                     f = FloatBytes(d[0], d[1], d[2]);
                     setState(EncoderState::BODY);
                 }

--- a/test/protocol.cpp
+++ b/test/protocol.cpp
@@ -267,9 +267,9 @@ TEST_CASE("Mime Type Size 0 - 20")
 
     unsigned char buffer[2048];
 
-    for (int mts=0; mts<=20; ++mts)
+    for (int mts = 0; mts <= 20; ++mts)
     {
-        for (int k=0; k<mts; ++k)
+        for (int k = 0; k < mts; ++k)
             mimeTypeBuffer[k] = (char)('A' + k);
         mimeTypeBuffer[mts] = 0;
 


### PR DESCRIPTION
Encoding when mimetype size < 3 was broken
but funnily it also whas when size % 3 == 0